### PR TITLE
CLUS-3776 allow path in controller url & remove/update controller by xid instead of url

### DIFF
--- a/README.md
+++ b/README.md
@@ -302,6 +302,11 @@ The controller parameters can be seen here: <https://github.com/severalnines/cmo
 curl -XPOST -k 'https://localhost:19051/proxy/controllers/test' -d'{"controller":{"url":"192.168.0.100:9501","name":"testadd","username":"someuser","password":"password"}}' | jq
 ````
 
+##### for updating controller - xid needs to be used instead of url:
+```bash
+curl -XPOST -k 'https://localhost:19051/proxy/controllers/update' -d'{"controller":{"xid":"co163ho8ia90oenf0o2g","name":"testadd","username":"someuser","password":"password"}}' | jq
+````
+
 ```json
 {
   "controller": {
@@ -319,9 +324,10 @@ curl -XPOST -k 'https://localhost:19051/proxy/controllers/test' -d'{"controller"
 
 This method can be used to remove a controller. Note the configuration will be
 updated too.
+##### Note - removing controller requires using xid, not url
 
 ```bash
-curl -XPOST -k 'https://localhost:19051/proxy/controllers/remove' -d'{"url":"192.168.0.100:9501"}' | jq
+curl -XPOST -k 'https://localhost:19051/proxy/controllers/remove' -d'{"xid":"co163ho8ia90oenf0o2g"}' | jq
 ```
 
 ```json

--- a/cmon/client.go
+++ b/cmon/client.go
@@ -297,11 +297,11 @@ func (client *Client) buildURI(module string) string {
 		u := &url.URL{
 			Host:   parsed.Host,
 			Scheme: parsed.Scheme,
-			Path:   "/v2/" + module,
+			Path:   parsed.Path + "/v2/" + module,
 		}
 		// it might already have the full URL
 		if strings.HasPrefix(module, "/v2") {
-			u.Path = module
+			u.Path = parsed.Path + module
 		}
 		return u.String()
 	}

--- a/config/config.go
+++ b/config/config.go
@@ -45,7 +45,7 @@ type ProxyUser struct {
 }
 
 type CmonInstance struct {
-	Xid         string `yaml:"xid" json:"-"` // stored in config file, not required on FE side
+	Xid         string `yaml:"xid" json:"xid"`
 	Url         string `yaml:"url" json:"url"`
 	Name        string `yaml:"name,omitempty" json:"name,omitempty"`
 	UseLdap     bool   `yaml:"useldap,omitempty" json:"useldap,omitempty"`
@@ -287,15 +287,15 @@ func (cfg *Config) AddController(cmon *CmonInstance, persist bool) error {
 }
 
 // RemoveConroller removes a cmon instance from config file and persists the configuration
-func (cfg *Config) RemoveController(url string, persist bool) error {
-	if cfg.ControllerByUrl(url) == nil {
+func (cfg *Config) RemoveController(xid string, persist bool) error {
+	if cfg.ControllerById(xid) == nil {
 		return cmonapi.NewError(cmonapi.RequestStatusObjectNotFound, "controller not found")
 	}
 
 	cfg.mtx.Lock()
 	removeAt := -1
 	for idx, cmon := range cfg.Instances {
-		if cmon.Url == url {
+		if cmon.Xid == xid {
 			removeAt = idx
 			break
 		}

--- a/config/config.go
+++ b/config/config.go
@@ -303,6 +303,8 @@ func (cfg *Config) RemoveController(xid string, persist bool) error {
 	if removeAt > -1 {
 		cfg.Instances[removeAt] = cfg.Instances[len(cfg.Instances)-1]
 		cfg.Instances = cfg.Instances[:len(cfg.Instances)-1]
+	} else {
+		return cmonapi.NewError(cmonapi.RequestStatusObjectNotFound, "controller not found")
 	}
 	cfg.mtx.Unlock()
 

--- a/multi/api/controlleraddremove.go
+++ b/multi/api/controlleraddremove.go
@@ -1,4 +1,5 @@
 package api
+
 // Copyright 2022 Severalnines AB
 //
 // This file is part of cmon-proxy.
@@ -8,7 +9,6 @@ package api
 // cmon-proxy is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
 //
 // You should have received a copy of the GNU General Public License along with cmon-proxy. If not, see <https://www.gnu.org/licenses/>.
-
 
 import (
 	cmonapi "github.com/severalnines/cmon-proxy/cmon/api"
@@ -30,4 +30,5 @@ type AddControllerResponse struct {
 // RemoveControllerRequest can be sent to remove a controller by URL
 type RemoveControllerRequest struct {
 	Url string `json:"url"`
+	Xid string `json:"xid"`
 }

--- a/multi/controllers.go
+++ b/multi/controllers.go
@@ -236,7 +236,7 @@ func (p *Proxy) RPCControllerUpdate(ctx *gin.Context) {
 	}
 
 	// remove & add it again
-	if err := p.Router(nil).Config.RemoveController(req.Controller.Url, false); err != nil {
+	if err := p.Router(nil).Config.RemoveController(req.Controller.Xid, false); err != nil {
 		cmonapi.CtxWriteError(ctx,
 			cmonapi.NewError(cmonapi.RequestStatusObjectNotFound, "Controller not found ("+err.Error()+")"))
 		return

--- a/multi/controllers.go
+++ b/multi/controllers.go
@@ -264,13 +264,13 @@ func (p *Proxy) RPCControllerRemove(ctx *gin.Context) {
 		}
 	}
 
-	if err := ctx.BindJSON(&req); err != nil || len(req.Url) < 1 {
+	if err := ctx.BindJSON(&req); err != nil || len(req.Xid) < 1 {
 		cmonapi.CtxWriteError(ctx,
 			cmonapi.NewError(cmonapi.RequestStatusInvalidRequest, "Invalid request."))
 		return
 	}
 
-	if err := p.Router(nil).Config.RemoveController(req.Url, true); err != nil {
+	if err := p.Router(nil).Config.RemoveController(req.Xid, true); err != nil {
 		cmonapi.CtxWriteError(ctx, err)
 		return
 	}


### PR DESCRIPTION
jira: https://severalnines.atlassian.net/browse/CLUS-3776

Regarding remove/update by xid
This logic was done before xid was introduced, it is better to xid for these operation.
Also this fixed a bug - was impossible to update controller url