### PR TITLE
CLUS-4031 added /config and /clusters/missingSchedules

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -195,6 +195,16 @@ func Load(filename string, loadFromCli ...bool) (*Config, error) {
 		config.Logfile = path.Join(opts.Opts.BaseDir, "ccmgr.log")
 	}
 
+	// default values for fetching backups
+	if config.FetchBackupDays < 1 {
+        config.FetchBackupDays = 7
+    }
+
+	// default values for fetching jobs
+	if config.FetchJobsHours < 1 {
+        config.FetchJobsHours = 12
+    }
+
 	// re-create the logger using the specified file name
 	loggerConfig := logger.DefaultConfig()
 	loggerConfig.LogFileName = config.Logfile

--- a/multi/api/backups.go
+++ b/multi/api/backups.go
@@ -36,6 +36,7 @@ type BackupOverview struct {
 type BackupExt struct {
 	*WithControllerID
 	*api.Backup
+	Key string 
 }
 
 type BackupListRequest struct {

--- a/multi/api/clusterlist.go
+++ b/multi/api/clusterlist.go
@@ -18,6 +18,7 @@ import (
 type ClusterExt struct {
 	*WithControllerID
 	*cmonapi.Cluster
+	Key string 
 }
 
 type ClustersOverviewRequest struct {

--- a/multi/api/config.go
+++ b/multi/api/config.go
@@ -1,0 +1,14 @@
+package api
+
+
+type ConfigExt struct {
+	FetchBackupsDays *int `json:"fetch_backups_days,omitempty"`
+	FetchJobsHours *int `json:"fetch_jobs_hours,omitempty"`
+}
+
+type ConfigResponse struct {
+	Config ConfigExt `json:"config"`
+}
+
+type ConfigRequest struct {
+}

--- a/multi/backups.go
+++ b/multi/backups.go
@@ -200,6 +200,7 @@ func (p *Proxy) RPCBackupsList(ctx *gin.Context) {
 					Xid:           xid,
 				},
 				Backup: data.Backups[idx],
+				Key: xid+"-"+strconv.FormatUint(backup.Metadata.ClusterID, 10),
 			}
 
 			resp.Backups = append(resp.Backups, b)
@@ -213,13 +214,6 @@ func (p *Proxy) RPCBackupsList(ctx *gin.Context) {
 	// sort first
 	order, desc := req.GetOrder()
 	switch order {
-	case "created":
-		sort.Slice(resp.Backups[:], func(i, j int) bool {
-			if desc {
-				i, j = j, i
-			}
-			return resp.Backups[i].Metadata.Created.T.Before(resp.Backups[j].Metadata.Created.T)
-		})
 	case "cluster_id":
 		sort.Slice(resp.Backups[:], func(i, j int) bool {
 			if desc {
@@ -247,6 +241,22 @@ func (p *Proxy) RPCBackupsList(ctx *gin.Context) {
 				i, j = j, i
 			}
 			return resp.Backups[i].Metadata.ID < resp.Backups[j].Metadata.ID
+		})
+	case "created":
+
+		sort.Slice(resp.Backups[:], func(i, j int) bool {
+			if desc {
+				i, j = j, i
+			}
+			return resp.Backups[i].Metadata.Created.T.Before(resp.Backups[j].Metadata.Created.T)
+		})
+	default:
+		desc = true
+		sort.Slice(resp.Backups[:], func(i, j int) bool {
+			if desc {
+				i, j = j, i
+			}
+			return resp.Backups[i].Metadata.Created.T.Before(resp.Backups[j].Metadata.Created.T)
 		})
 	}
 

--- a/multi/config.go
+++ b/multi/config.go
@@ -1,0 +1,17 @@
+package multi
+
+import (
+	"net/http"
+
+	"github.com/gin-gonic/gin"
+	"github.com/severalnines/cmon-proxy/multi/api"
+)
+
+func (p *Proxy) RPCConfigHandler(ctx *gin.Context) {
+	var resp api.ConfigResponse
+
+	resp.Config.FetchBackupsDays = &p.cfg.FetchBackupDays
+	resp.Config.FetchJobsHours = &p.cfg.FetchJobsHours
+
+	ctx.JSON(http.StatusOK, resp)
+}

--- a/multi/jobs.go
+++ b/multi/jobs.go
@@ -215,6 +215,14 @@ func (p *Proxy) RPCJobsList(ctx *gin.Context) {
 			}
 			return resp.Jobs[i].Created.T.Before(resp.Jobs[j].Created.T)
 		})
+	default:
+		desc = true
+		sort.Slice(resp.Jobs[:], func(i, j int) bool {
+			if desc {
+				i, j = j, i
+			}
+			return resp.Jobs[i].Created.T.Before(resp.Jobs[j].Created.T)
+		})
 	}
 	if req.ListRequest.PerPage > 0 {
 		// then handle the pagination

--- a/rpcserver/server.go
+++ b/rpcserver/server.go
@@ -276,6 +276,9 @@ func Start(cfg *config.Config) {
 	// aggregating APIs for WEB UI v0
 	p := s.Group("/proxy")
 	{
+
+		p.GET("/config", proxy.RPCConfigHandler)
+		p.POST("/config", proxy.RPCConfigHandler)
 		auth := p.Group("/auth")
 		{
 			auth.GET("/check", proxy.RPCAuthCheckHandler)
@@ -298,6 +301,9 @@ func Start(cfg *config.Config) {
 
 			clusters.GET("/list", proxy.RPCClustersList)
 			clusters.POST("/list", proxy.RPCClustersList)
+
+			clusters.GET("/missingSchedules", proxy.RPCClustersListMissingSchedules)
+			clusters.POST("/missingSchedules", proxy.RPCClustersListMissingSchedules)
 
 			clusters.GET("/hosts", proxy.RPCClustersHostList)
 			clusters.POST("/hosts", proxy.RPCClustersHostList)


### PR DESCRIPTION
Jira: https://severalnines.atlassian.net/browse/CLUS-4030

- Added /config that returns cmon proxy config
- Added /clusters/missingSchedules that returns cluster with missing schedules
- Fixed default sort for cluster list (it was sorting randomly by default)
- Fixed default sort for job list (it was sorting randomly by default)
- Fixed default sort for backup list (it was sorting randomly by default)