### PR TITLE
CLUS-4388 test auth before writing creds in router

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -111,6 +111,23 @@ func (cmon *CmonInstance) Verify() error {
 	return nil
 }
 
+func (cmon *CmonInstance) Copy() *CmonInstance {
+	instance := &CmonInstance{
+		Xid:           cmon.Xid,
+		Url:           cmon.Url,
+		Name:          cmon.Name,
+		UseCmonAuth:   cmon.UseCmonAuth,
+		Username:      cmon.Username,
+		UseLdap:       cmon.UseLdap,
+		Keyfile:       cmon.Keyfile,
+		Password:      cmon.Password,
+		FrontendUrl:   cmon.FrontendUrl,
+		CMONSshHost:   cmon.CMONSshHost,
+		CMONSshSecure: cmon.CMONSshSecure,
+	}
+	return instance
+}
+
 // Save persist the configuration to the file it was loaded from
 func (cfg *Config) Save() error {
 	cfg.mtx.RLock()

--- a/multi/router/router.go
+++ b/multi/router/router.go
@@ -149,19 +149,7 @@ func (router *Router) Sync() {
 	// and create the new ones
 	for _, addr := range router.Config.ControllerUrls() {
 		if instance := router.Config.ControllerByUrl(addr); instance != nil {
-			actualConfig := &config.CmonInstance{
-				Xid:           instance.Xid,
-				Url:           instance.Url,
-				Name:          instance.Name,
-				UseCmonAuth:   instance.UseCmonAuth,
-				Username:      instance.Username,
-				UseLdap:       instance.UseLdap,
-				Keyfile:       instance.Keyfile,
-				Password:      instance.Password,
-				FrontendUrl:   instance.FrontendUrl,
-				CMONSshHost:   instance.CMONSshHost,
-				CMONSshSecure: instance.CMONSshSecure,
-			}
+			actualConfig := instance.Copy()
 			// in case of LDAP the credentials aren't stored in config, but in runtime only
 			if router.Ldap.Use && actualConfig.UseLdap {
 				actualConfig.Username = router.Ldap.Username


### PR DESCRIPTION
Related PR in UI: https://github.com/severalnines/frontend-hub/pull/109

Discovered issue while working on registration in MCC, so linking this to registration ticket:

jira: https://severalnines.atlassian.net/browse/CLUS-4388

Issues resolved:
1) authentication in cmon-proxy without password while {username} session is active
cmon proxy was using user from another active session to authenticate {username} even if password was incorrect, this was leading to ability to authenticate with any password combination

2) breaking current session by overriding credentials in router for {username}
Nature of the issue is that we were writing credentials in router before testing if those credentials are actually correct, overriding credentials in router was breaking current active session.

Issues probably still present for LDAP authentication, will test it separately

