### PR TITLE
CLUS-5931 fix ldap connection when enabling mcc

### DIFF
--- a/ccmgradm/main.go
+++ b/ccmgradm/main.go
@@ -246,7 +246,6 @@ func main() {
 					Url:         cmonUrl,
 					CMONSshHost: cmonSshUrl,
 					Name:        "local",
-					UseCmonAuth: true,
 					FrontendUrl: "localhost",
 				}
 

--- a/cmon/client.go
+++ b/cmon/client.go
@@ -260,9 +260,6 @@ func (client *Client) Authenticate() error {
 
 	client.lastRequestStatus = api.RequestStatusAuthRequired
 
-	if client.Instance.UseLdap {
-		return fmt.Errorf("LDAP authentication is required")
-	}
 	return fmt.Errorf("no password or keyfile is defined")
 }
 
@@ -271,7 +268,6 @@ func (client *Client) AuthenticateWithPassword() error {
 		WithOperation: &api.WithOperation{
 			Operation: "authenticateWithPassword",
 		},
-		LdapOnly: client.Instance.UseLdap && !client.Instance.UseCmonAuth,
 		UserName: client.Instance.Username,
 		Password: client.Instance.Password,
 	}
@@ -283,11 +279,6 @@ func (client *Client) AuthenticateWithPassword() error {
 
 	if ar.RequestStatus != api.RequestStatusOk {
 		return api.NewErrorFromResponseData(ar.WithResponseData)
-	}
-
-	if ar.User.Origin == "LDAP" && !client.Instance.UseLdap {
-		client.ResetSession()
-		return fmt.Errorf("ldap user is not allowed to login")
 	}
 
 	client.mtx.Lock()

--- a/config/config.go
+++ b/config/config.go
@@ -347,6 +347,29 @@ func (cfg *Config) AddController(cmon *CmonInstance, persist bool) error {
 	return nil
 }
 
+func (cfg *Config) SetLdapEnabled(xid string, ldapEnabled bool, persist bool) error {
+	if err := cfg.ControllerById(xid).Verify(); err != nil {	
+		return err
+	}
+
+	cfg.mtx.Lock()
+	
+	for idx, cmon := range cfg.Instances {
+		if cmon.Xid == xid {
+			cfg.Instances[idx].UseLdap = ldapEnabled
+			cfg.Instances[idx].UseCmonAuth = !ldapEnabled
+			break
+		}
+	}
+	
+	cfg.mtx.Unlock()
+
+	if persist {
+		return cfg.Save()
+	}
+	return nil
+}
+
 // RemoveConroller removes a cmon instance from config file and persists the configuration
 func (cfg *Config) RemoveController(xid string, persist bool) error {
 	if cfg.ControllerById(xid) == nil {

--- a/multi/api/controllerstatus.go
+++ b/multi/api/controllerstatus.go
@@ -46,8 +46,6 @@ type ControllerStatus struct {
 	FrontendUrl   string                    `json:"frontend_url,omitempty"`
 	Version       string                    `json:"version"`
 	StatusMessage string                    `json:"status_message"`
-	Ldap          bool                      `json:"ldap"`
-	UseCmonAuth   bool                      `json:"use_cmon_auth"`
 	Status        CmonStatus                `json:"status"`
 	LastUpdated   cmonapi.NullTime          `json:"last_updated"`
 	LastSeen      cmonapi.NullTime          `json:"last_seen"`

--- a/multi/api/mcc.go
+++ b/multi/api/mcc.go
@@ -4,7 +4,6 @@ import cmonapi "github.com/severalnines/cmon-proxy/cmon/api"
 
 type EnableMccRequest struct {
 	User        *UserWithPassword `json:"user,omitempty"`
-	LdapEnabled bool              `json:"ldap_enabled,omitempty"`
 }
 
 type EnableMccResponse struct {

--- a/multi/api/mcc.go
+++ b/multi/api/mcc.go
@@ -3,7 +3,8 @@ package api
 import cmonapi "github.com/severalnines/cmon-proxy/cmon/api"
 
 type EnableMccRequest struct {
-	User *UserWithPassword `json:"user,omitempty"`
+	User        *UserWithPassword `json:"user,omitempty"`
+	LdapEnabled bool              `json:"ldap_enabled,omitempty"`
 }
 
 type EnableMccResponse struct {

--- a/multi/authentication.go
+++ b/multi/authentication.go
@@ -343,7 +343,7 @@ func (p *Proxy) controllerLogin(ctx *gin.Context, req *api.LoginRequest, resp *a
 	// check if we have any cmon configured to use LDAP or CMON authentication
 	useController := false
 	for _, instance := range p.cfg.Instances {
-		if instance != nil && (instance.UseLdap || instance.UseCmonAuth) {
+		if instance != nil {
 			useController = true
 			break
 		}

--- a/multi/controllers.go
+++ b/multi/controllers.go
@@ -76,8 +76,6 @@ func (p *Proxy) RPCControllerStatus(ctx *gin.Context) {
 		status.ControllerID = c.ControllerID()
 		status.Xid = c.Xid()
 		status.Status = api.Ok
-		status.Ldap = c.Client.Instance.UseLdap
-		status.UseCmonAuth = c.Client.Instance.UseCmonAuth
 		status.FrontendUrl = c.Client.Instance.FrontendUrl
 		status.LastUpdated.T = time.Now()
 
@@ -111,18 +109,6 @@ func (p *Proxy) RPCControllerStatus(ctx *gin.Context) {
 			status.LastSeen.T = time.Now()
 		}
 
-		if c.Client.Instance.UseLdap {
-			if status.Status == api.Ok {
-				status.StatusMessage = "LDAP authentication ok."
-			} else if status.Status == api.AuthenticationError {
-				if len(status.StatusMessage) > 1 && !strings.HasPrefix(status.StatusMessage, "LDAP") {
-					status.StatusMessage = "LDAP: " + status.StatusMessage
-				} else {
-					status.StatusMessage = "LDAP authentication failed."
-				}
-			}
-		}
-
 		// persist in cache for later use
 		mtx.Lock()
 		controllerStatusCache[addr] = status
@@ -148,7 +134,6 @@ func (p *Proxy) pingOne(instance *config.CmonInstance) *api.ControllerStatus {
 		Version:      client.ServerVersion(),
 		Url:          instance.Url,
 		Name:         instance.Name,
-		Ldap:         instance.UseLdap,
 		Status:       api.Ok,
 	}
 	if resp != nil && len(resp.Version) > 0 {
@@ -164,17 +149,7 @@ func (p *Proxy) pingOne(instance *config.CmonInstance) *api.ControllerStatus {
 			retval.Status = api.AuthenticationError
 		}
 	}
-	if instance.UseLdap {
-		if retval.Status == api.Ok {
-			retval.StatusMessage = "LDAP authentication ok."
-		} else if retval.Status == api.AuthenticationError {
-			if len(retval.StatusMessage) > 1 {
-				retval.StatusMessage = "LDAP: " + retval.StatusMessage
-			} else {
-				retval.StatusMessage = "LDAP authentication failed."
-			}
-		}
-	}
+	
 	return retval
 }
 
@@ -190,14 +165,6 @@ func (p *Proxy) RPCControllerTest(ctx *gin.Context) {
 	// Get current in-memory credentials
 	auth := p.Router(ctx).AuthController
 	if auth.Use {
-		if req.Controller.Xid != "" { 
-			// which means it is editing existing controller
-			// @TODO: check how LDAP works with this
-			req.Controller.Username = auth.Username
-			req.Controller.Password = auth.Password
-		}
-		// Use these credentials for a new controller
-		req.Controller.UseCmonAuth = false
 		// Now you can authenticate this instance
 		client := cmon.NewClient(req.Controller, p.Router(ctx).Config.Timeout)
 		err := client.Authenticate()

--- a/multi/mcc.go
+++ b/multi/mcc.go
@@ -73,6 +73,12 @@ func (p *Proxy) EnableHandler(ctx *gin.Context) {
 		}
 	}
 
+	if req.LdapEnabled {
+		cfg.SetLdapEnabled(cfg.SingleController, true, true)
+	} else {
+		cfg.SetLdapEnabled(cfg.SingleController, false, true)
+	}
+
 	// Enable MCC mode
 	cfg.SingleController = ""
 	if err := cfg.Save(); err != nil {

--- a/multi/mcc.go
+++ b/multi/mcc.go
@@ -73,12 +73,6 @@ func (p *Proxy) EnableHandler(ctx *gin.Context) {
 		}
 	}
 
-	if req.LdapEnabled {
-		cfg.SetLdapEnabled(cfg.SingleController, true, true)
-	} else {
-		cfg.SetLdapEnabled(cfg.SingleController, false, true)
-	}
-
 	// Enable MCC mode
 	cfg.SingleController = ""
 	if err := cfg.Save(); err != nil {

--- a/multi/router/router.go
+++ b/multi/router/router.go
@@ -151,7 +151,7 @@ func (router *Router) Sync() {
 		if instance := router.Config.ControllerByUrl(addr); instance != nil {
 			actualConfig := instance.Copy()
 			// in case of LDAP the credentials aren't stored in config, but in runtime only
-			if router.AuthController.Use && (actualConfig.UseLdap || actualConfig.UseCmonAuth) {
+			if router.AuthController.Use {
 				actualConfig.Username = router.AuthController.Username
 				actualConfig.Password = router.AuthController.Password
 			}
@@ -248,8 +248,7 @@ func (router *Router) GetControllerUser() *api.User {
 	for _, addr := range router.Config.ControllerUrls() {
 		if cmon := router.Cmon(addr); cmon != nil &&
 			cmon.Client != nil &&
-			cmon.Client.Instance != nil &&
-			(cmon.Client.Instance.UseLdap || cmon.Client.Instance.UseCmonAuth) {
+			cmon.Client.Instance != nil {
 			user := cmon.Client.User()
 			if user != nil {
 				return user


### PR DESCRIPTION
Jira: https://severalnines.atlassian.net/browse/CLUS-5931
- Problem was that when enabling mcc, if user has enabled LDAP, the controller was still configured as `use cmon auth`.
- Solved by removing the ability to pick LDAP or CMON, and let every cmon to do the auth by its own.